### PR TITLE
add mTLS-to-TSA test for sigstore/cosign PR3052

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ runs `cosign sign` and `cosign verify` with the ["keyless verification"](https:/
 - `crane` (to publish a test image to ttl.sh) - https://github.com/michaelsauter/crane, `brew install crane`
 
 ## sigstore/cosign Pull Request 2845
-This script is done as part of testing for https://github.com/sigstore/cosign/pull/2845 "verify command: support keyless verification using only a provided certificate chain with non-fulcio roots".
+This script was done as part of testing for https://github.com/sigstore/cosign/pull/2845 "verify command: support keyless verification using only a provided certificate chain with non-fulcio roots".
 It is expected to fail the verification with the trunk version of sigstore. If you want to try this
 before the PR is merged, please check out the PR branch https://github.com/dmitris/cosign/tree/keyless-without-fulcio.
 
@@ -22,3 +22,7 @@ or through the `IMAGE_URI_DIGEST` environment variable:
 ```bash
 ./run.sh ttl.sh/2291f828@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16
 ```
+
+## sigstore/cosign Pull Request 3052 - mTLS to TSA
+To test `cosign` support for an mTLS connection to the timestamp server ([sigstore/cosign#3052](https://github.com/sigstore/cosign/pull/3052)), use `./run-tls.sh` and
+see the "Sample run" example on the top of that script for the mTLS-related parameters.

--- a/run-tls.sh
+++ b/run-tls.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+## Requirements
+# - cosign
+# - crane
+# - go
+
+# Sample run - assumptions:
+# 1) $CERT_BASE is the directory with certificates - adjust the file name as needed
+# 2) change the value of TIMESTAMP_SERVER_URL to the URL of the timestamp server started with TLS credentials
+#
+# TIMESTAMP_CLIENT_CACERT=$CERT_BASE/cacert.pem TIMESTAMP_CLIENT_CERT=$CERT_BASE/cert.pem TIMESTAMP_CLIENT_KEY=$CERT_BASE/key.pem TIMESTAMP_SERVER_NAME=change.to.real.server.name TIMESTAMP_SERVER_URL=https://freetsa.org/tsr bash -x ./run.sh |& tee /tmp/out
+
+IMG=${IMAGE_URI_DIGEST:-}
+if [[ "$#" -ge 1 ]]; then
+	IMG=$1
+elif [[ -z "${IMG}" ]]; then
+	# Upload an image to ttl.sh - commands from https://docs.sigstore.dev/cosign/keyless/
+	SRC_IMAGE=busybox
+	SRC_DIGEST=$(crane digest busybox)
+	IMAGE_URI=ttl.sh/$(uuidgen | head -c 8 | tr 'A-Z' 'a-z')
+	crane cp $SRC_IMAGE@$SRC_DIGEST $IMAGE_URI:3h
+	IMG=$IMAGE_URI@$SRC_DIGEST
+fi
+
+echo "IMG (IMAGE_URI_DIGEST): $IMG, TIMESTAMP_SERVER_URL: $TIMESTAMP_SERVER_URL"
+
+GOBIN=/tmp GOPROXY=https://proxy.golang.org,direct go install -v github.com/dmitris/gencert@latest
+
+rm -f *.pem import-cosign.* key.pem
+
+
+# use gencert to generate CA, keys and certificates
+echo "generate keys and certificates with gencert"
+
+passwd=$(uuidgen | head -c 32 | tr 'A-Z' 'a-z')
+rm -f *.pem import-cosign.* && /tmp/gencert && COSIGN_PASSWORD="$passwd" cosign import-key-pair --key key.pem
+
+COSIGN_PASSWORD="$passwd" cosign sign --timestamp-server-url "${TIMESTAMP_SERVER_URL}" \
+	--timestamp-client-cacert ${TIMESTAMP_CLIENT_CACERT} --timestamp-client-cert ${TIMESTAMP_CLIENT_CERT} \
+	--timestamp-client-key ${TIMESTAMP_CLIENT_KEY} --timestamp-server-name ${TIMESTAMP_SERVER_NAME}\
+	--upload=true --tlog-upload=false --key import-cosign.key --certificate-chain cacert.pem --cert cert.pem $IMG
+
+# key is now longer needed
+rm -f key.pem import-cosign.*
+
+echo "cosign verify:"
+cosign verify --insecure-ignore-tlog --insecure-ignore-sct --check-claims=true \
+	--certificate-identity-regexp 'xyz@nosuchprovider.com' --certificate-oidc-issuer-regexp '.*' \
+	--certificate-chain cacert.pem $IMG


### PR DESCRIPTION
adding a test script `run-mtls.sh` for https://github.com/sigstore/cosign/pull/3052, with the mTLS connection from `cosign` (running `cosign sign` command) to the TSA server.