### PR TITLE
add timestamp_certchain to cosign verify in run.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ gencert
 import-cosign.key
 import-cosign.pub
 key.pem
+tsa.crt
+tsa-certchain.pem

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,21 @@ set -euo pipefail
 
 IMG=${IMAGE_URI_DIGEST:-}
 TIMESTAMP_SERVER_URL=${TIMESTAMP_SERVER_URL:="https://freetsa.org/tsr"}
+TIMESTAMP_CERTCHAIN=${TIMESTAMP_CERTCHAIN:=""}
+if [[ "${TIMESTAMP_SERVER_URL}" == "https://freetsa.org/tsr" ]]; then
+	# download the TSA and TSA CA certificates and create the certificate chain file
+	rm -fr tsa.crt cacert.pem tsa-certchain.pem
+	curl -sSfL https://freetsa.org/files/tsa.crt -o tsa.crt
+	curl -sSfL https://freetsa.org/files/cacert.pem -o cacert.pem
+	cat cacert.pem tsa.crt > tsa-certchain.pem
+	echo "(PWD: $PWD) tsa-certchain.pem:"
+	cat tsa-certchain.pem
+	TIMESTAMP_CERTCHAIN="tsa-certchain.pem"
+fi
+if [[ -z "${TIMESTAMP_CERTCHAIN}" ]]; then
+	echo "TIMESTAMP_CERTCHAIN is not set and TIMESTAMP_SERVER_URL ${TIMESTAMP_SERVER_URL} is not default (https://freetsa.org/tsr)"
+	exit 1
+fi
 if [[ "$#" -ge 1 ]]; then
 	IMG=$1
 elif [[ -z "${IMG}" ]]; then
@@ -19,18 +34,16 @@ elif [[ -z "${IMG}" ]]; then
 	IMG=$IMAGE_URI@$SRC_DIGEST
 fi
 
-echo "IMG (IMAGE_URI_DIGEST): $IMG, TIMESTAMP_SERVER_URL: $TIMESTAMP_SERVER_URL"
+echo "IMG (IMAGE_URI_DIGEST): $IMG, TIMESTAMP_SERVER_URL: $TIMESTAMP_SERVER_URL, TIMESTAMP_CERTCHAIN: $TIMESTAMP_CERTCHAIN"
 
 GOBIN=/tmp GOPROXY=https://proxy.golang.org,direct go install -v github.com/dmitris/gencert@latest
 
-rm -f *.pem import-cosign.* key.pem
-
-
+rm -f ca-key.pem key.pem
 # use gencert to generate CA, keys and certificates
 echo "generate keys and certificates with gencert"
 
 passwd=$(uuidgen | head -c 32 | tr 'A-Z' 'a-z')
-rm -f *.pem import-cosign.* && /tmp/gencert && COSIGN_PASSWORD="$passwd" cosign import-key-pair --key key.pem
+rm -f import-cosign.* && /tmp/gencert && COSIGN_PASSWORD="$passwd" cosign import-key-pair --key key.pem
 
 echo "cosign sign:"
 COSIGN_PASSWORD="$passwd" cosign sign --timestamp-server-url "${TIMESTAMP_SERVER_URL}" --upload=true --tlog-upload=false --key import-cosign.key --certificate-chain cacert.pem --cert cert.pem $IMG
@@ -39,7 +52,9 @@ COSIGN_PASSWORD="$passwd" cosign sign --timestamp-server-url "${TIMESTAMP_SERVER
 rm -f key.pem import-cosign.* 
 
 echo "cosign verify:"
-cosign verify --insecure-ignore-tlog --insecure-ignore-sct --check-claims=true \
+cosign verify --private-infrastructure --insecure-ignore-sct --check-claims=true \
 	--certificate-identity-regexp 'xyz@nosuchprovider.com' --certificate-oidc-issuer-regexp '.*' \
-	--certificate-chain cacert.pem $IMG
+	--certificate-chain cacert.pem --timestamp-certificate-chain=$TIMESTAMP_CERTCHAIN $IMG
 
+# cleanup
+rm -f tsa-certchain.pem tsa.crt


### PR DESCRIPTION
Fix `run.sh` to use the timestamp certificate chain in `cosign verify --timestamp-certificate-chain`.